### PR TITLE
init remote dev env

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,0 +1,30 @@
+# Display source context
+set pagination off
+set print pretty on
+set print elements 0        # Show all elements of arrays
+set print null-stop on      # Stop strings at NULL
+
+# Enable line numbers in backtraces
+set backtrace limit 50
+
+# Show register values on stop
+set verbose on
+set history save on
+set history size 1000
+
+# Automatically load symbols for shared libraries
+set auto-solib-add on
+
+# Set default breakpoint pending behavior
+set breakpoint pending on
+
+# Add source directories (can add multiple)
+dir src
+dir /home/user/code/xwm
+
+# Automatically run a command on start to-
+# 1. Set a breakpoint at main
+# 2. Immediately start the program (run)
+# 3. Pause at the first line of user code
+break main
+run

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/
+.vagrant/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,78 @@
+# xwm Development Guide
+
+This document outlines the complete development and debugging workflow for `xwm`, a fork of `dwm` and `dmenu`, packaged with a remote debugging environment using Vagrant, libvirt, and gdb.
+
+---
+
+## Project Overview
+
+This repo contains:
+- `wm`: the main window manager
+- `menu`: the app launcher menu
+- Shared drawing and utility code under `src/common`
+
+Builds are managed with `make`. Debugging is done remotely inside a VM that mirrors the host project structure for seamless GDB integration.
+
+---
+
+## Required packages 
+```
+sudo apt install gcc make gdb vagrant rsync libvirt-daemon-system libvirt-clients qemu-kvm bridge-utils remote-viewer
+```
+
+## First-Time Setup
+
+Before using the `Makefile` targets for building or debugging, the development VM must be created and started with Vagrant.
+
+### 1. Start the VM
+
+Use the following command to initialize the virtual machine using the Libvirt provider:
+
+```
+vagrant up --provider=libvirt
+```
+See the lifecycle targets below for modifying the state of this VM after its been created.  
+
+
+##  Makefile Targets
+
+The `Makefile` provides a complete build, deploy, debug, and VM lifecycle workflow.
+
+###  Local Build Targets
+
+| Target          | Description                                             |
+|------------------|---------------------------------------------------------|
+| `make`           | Builds both `wm` and `menu` binaries                    |
+| `make clean`     | Removes all build artifacts (`*.o`, `wm`, `menu`)       |
+| `make install`   | Installs binaries and scripts to `${PREFIX}/bin`        |
+| `make uninstall` | Removes installed files from `${PREFIX}/bin`            |
+
+---
+
+###  VM Development Targets
+
+The typical test iteration involves running these four commands in the sequence 
+seen below. The user will end with a VM running up to date code from the current repo state 
+as well as a terminal running gdb and a terminal tailing all relevant logs.  There will also be 
+a VNC graphical window. To redeploy an updated version, run make rebuild. 
+Quit gdb which will terminate xwm and re-run `make debug` to restart the wm 
+with the latest version.  
+
+| Target          | Description                                                                 |
+|------------------|-----------------------------------------------------------------------------|
+| `make rebuild`   | Syncs code to the VM and triggers `vagrant provision` to rebuild `wm`       |
+| `make tail-log`  | Tails runtime log output from the VM (`/var/log/wm`) using `vagrant ssh`    |
+| `make view`      | Launches `remote-viewer` to view the VM's GUI 				|
+| `make debug`     | Launches `gdb` in TUI mode and attaches to the remote `gdbserver` running `wm` |
+
+---
+
+###  VM Lifecycle Targets
+
+If the VM gets in an odd state, run `make reload` to reset state and start fresh.  
+
+| Target         | Description                                            |
+|----------------|--------------------------------------------------------|
+| `make reload`  | Reloads the VM (e.g. after config or networking changes) |
+| `make stop`    | Halts the VM   |
+

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,17 @@
-# Fork of dwm and dmenu, combined in one project 
+# Fork of dwm and dmenu, combined in one project
 # See LICENSE file for copyright and license details.
 
 include config.mk
 
+# === Source Configuration ===
+
 COMMON_SRC = src/common/drw.c src/common/util.c
-WM_SRC = src/wm/wm.c $(COMMON_SRC)
-MENU_SRC = src/menu/menu.c $(COMMON_SRC)
-SRC = $(WM_SRC) $(MENU_SRC) 
-OBJ = ${SRC:.c=.o}
+WM_SRC     = src/wm/wm.c $(COMMON_SRC)
+MENU_SRC   = src/menu/menu.c $(COMMON_SRC)
+SRC        = $(WM_SRC) $(MENU_SRC)
+OBJ        = ${SRC:.c=.o}
+
+# === Build Targets ===
 
 all: wm menu
 
@@ -29,15 +33,58 @@ install: all
 	mkdir -p ${DESTDIR}${PREFIX}/bin
 	cp -f wm menu ${DESTDIR}${PREFIX}/bin
 	chmod 755 ${DESTDIR}${PREFIX}/bin/wm
-	chmod 755 $(DESTDIR)$(PREFIX)/bin/menu
+	chmod 755 ${DESTDIR}${PREFIX}/bin/menu
 	cp -f src/scripts/launch_app src/scripts/switch_app ${DESTDIR}${PREFIX}/bin
-	chmod 755 $(DESTDIR)$(PREFIX)/bin/launch_app
-	chmod 755 $(DESTDIR)$(PREFIX)/bin/switch_app
+	chmod 755 ${DESTDIR}${PREFIX}/bin/launch_app
+	chmod 755 ${DESTDIR}${PREFIX}/bin/switch_app
 
 uninstall:
-	rm -f ${DESTDIR}${PREFIX}/bin/wm\
-		${DESTDIR}${PREFIX}/bin/menu\
-		${DESTDIR}${PREFIX}/bin/launch_app\
-		${DESTDIR}${PREFIX}/bin/switch_app
+	rm -f ${DESTDIR}${PREFIX}/bin/wm \
+	      ${DESTDIR}${PREFIX}/bin/menu \
+	      ${DESTDIR}${PREFIX}/bin/launch_app \
+	      ${DESTDIR}${PREFIX}/bin/switch_app
 
-.PHONY: all clean dist install uninstall
+# === Remote Development & Debugging ===
+
+# VM Configuration
+REMOTE_IP := $(shell vagrant ssh-config 2>/dev/null | awk '/HostName/ { print $$2 }')
+REMOTE_USER := vagrant
+REMOTE_DIR := /home/$(REMOTE_USER)/xwm
+GDB_PORT := 5555
+
+# Sync code to VM and rebuild with correct HOST_IP context
+rebuild:
+	vagrant rsync
+	vagrant ssh -c 'bash /home/vagrant/xwm/scripts/rebuild.sh'
+
+debug:
+	@echo "Connecting to gdbserver at $(REMOTE_IP):$(GDB_PORT)..."
+	@gdb -tui -ex "target remote $(REMOTE_IP):$(GDB_PORT)" -ex continue
+
+# Tail log output from inside VM (2)  
+tail-log:
+	vagrant ssh -c 'touch /var/log/wm && tail -f /var/log/wm'
+
+# View the VM GUI (3)
+view:
+	remote-viewer vnc://127.0.0.1:5901 &
+
+# Composite target of 1, 2, and 3 above within tmux
+start: rebuild view
+	@tmux new-session -d -s xwm_dev \
+		"make debug" \; \
+		split-window -v "make tail-log" \; \
+		select-pane -t 0 \; \
+		attach-session -t xwm_dev
+
+# === VM Lifecycle Commands ===
+
+# Reloads the VM (useful for network or config changes)
+reload:
+	vagrant reload
+
+# Gracefully halts the VM
+stop:
+	vagrant halt
+
+.PHONY: all clean install uninstall deploy tail-log debug start

--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
 
 # xwm - eXperimental window manager
 
-xwm is an experiment that started as a fork of dwm and dmenu. I've been interested in hacking on a wm and instead of starting from scratch thought it'd be more fun to start with a fork of the wm that I've been using for years and have come to appreciate. Kind of like learning how a car works by slowly taking it apart, I'm using dwm to learn about xlib.
+## Overview
 
-One potential goal is to boil this wm into an even simpler version that will be useful on touch devices like the reMarkable 1 and/or the PinePhone. The idea is to use dwm as the start point for the xlib wm components and dmenu for the app launcher which instead of being typing centric will list out gui apps and be scrollable and clickable. Also will be able to list open processes in that launcher as well as programs, and modifying the classic layout to instead have one main client, and all others are hidden. One exception will need to be the onscreen keyboard which will involve learning from the team behind the sxmo-dwm project and use a dock patch where svkb declares itself as a special type of client that gets handled by dwm specially.
+**xwm** is a minimalist X11 window manager focused on single-application visibility with a built-in launcher and switcher for streamlined user interaction.
+
+Inspired by `dwm` and `dmenu`, **xwm** is designed to run efficiently on constrained or touch-based environments such as the reMarkable 1 and the PinePhone.
+
+### Key Features
+
+- **Single Visible Client**: Only one window is shown at a time; all others are hidden.
+- **Integrated App Launcher**: A scrollable and clickable launcher (built on `dmenu`) replaces traditional typing-based app search.
+- **Process and Application View**: The launcher can display both installed applications and currently running processes.
+- **Touch Device Support**: Designed to work with on-screen keyboards and limited input; will support special client handling (e.g., `svkbd`) using concepts from the [sxmo project](https://sxmo.org) and `dwm`'s dock patch.
+
+This project extends the simplicity of `dwm` and `dmenu` to deliver a clean, distraction-free windowing model with touch compatibility.
 
 ## Current Project Status & Notes
 The next todo is to make the menu clickable, then add the keyboard, then gesture support.  
@@ -29,17 +40,6 @@ I'm removing features partly as an exercise, but it has the benefit of reducing 
 dwm 2165 / wm 1582 SLOC  
 dmenu 796 / menu 665 SLOC 
 
-### Screenshots
-#### App Launcher
-![launch_app](https://github.com/trent234/xwm/assets/22989914/1d087cd8-7fc9-4022-b0a4-4ed7c619f864)
-
-#### App Switcher
-![switch_app](https://github.com/trent234/xwm/assets/22989914/6aafe1ca-10f2-479e-a632-96db882db6ca)
-
-#### App Selected
-![app](https://github.com/trent234/xwm/assets/22989914/24fb2318-3a57-4ae2-8b0c-d4f7dbfc6cb0)
-
-
 #### wm
 
  This is a dynamic window manager is designed like any other X client as well. It is
@@ -59,7 +59,10 @@ dmenu 796 / menu 665 SLOC
 
 ## Requirements
 
-In order to build you need the Xlib header files.
+In order to build you need the Xlib header files e.g-  
+```
+sudo apt install libx11-dev
+```
 
 ## Installation
 
@@ -79,74 +82,24 @@ Add the following line to your `.xinitrc` to start the window manager using `sta
 exec wm
 ```
 
-In order to display status info in the bar, you can do something like this in your `.xinitrc`:
+## Usage
 
-```shell
-while xsetroot -name "`date` `uptime | sed 's/.*,//'`"
-do
-	sleep 1
-done &
-exec wm
-```
+These shortcuts are modifiable in wm.h but below outlines the defaults.  
+The window manager uses `Alt` (`Mod1`) as the primary modifier key:
 
+- `` Alt + f `` — Launch application launcher (`launch_app`)
+- `` Alt + j `` — Switch to a different application (`switch_app`)
+- `` Alt + Enter `` — Launch terminal (`uxterm`)
+- `` Alt + b `` — Toggle the visibility of the status bar
+- `` Alt + Shift + c `` — Close the focused window
+- `` Alt + Shift + q `` — Quit the window manager
 
-## Developing & debugging
+### Screenshots
+#### App Launcher
+![launch_app](https://github.com/trent234/xwm/assets/22989914/1d087cd8-7fc9-4022-b0a4-4ed7c619f864)
 
-I use virtualbox with a virtual NAT as the integral component of the build-run cycle. Create a debian 12 VM and note its IP. 
-From the host, within the repo parent run-  
-```
-scp -r xwm user@192.168.122.35:/tmp
-```
-Then I can SSH to the VM like so-  
-```
-ssh user@192.168.122.35  
-```
-For a new VM certain packages will be required- 
-* To pull
-  * git
-* Project dependencies
-  * libx11-dev
-  * libxft-dev
-* To build
-  * make
-  * gcc
-* To run
-  * xorg
-* To debug
-  * gdb
-  * gdbserver
-  * valgrind
-* To populate many apps to test with
-  * gnome
-* Missing deps for some gnome apps
-  * dbus-launch  
+#### App Switcher
+![switch_app](https://github.com/trent234/xwm/assets/22989914/6aafe1ca-10f2-479e-a632-96db882db6ca)
 
-SSH'd into the VM, move the source that was copied over to the same dir path as on the host (required for gdb)- 
-```
-mv /tmp/xwm /path/to/host/repo/dir
-```
-Create an ~/.xinitrc with these contents-
-```
-vi ~/.xinitrc
-exec gdbserver 192.168.122.35:5555 wm > /var/log/wm 2>&1
-```
-And in a separate terminal SSH'd in to the VM run- 
-```
-touch /var/log/wm
-tail -f /var/log/wm
-```
-Then, in a separate terminal SSH'd into the VM, start the wm with-
-```
-startx
-```
-Then on the host, from the repo root dir-
-```
-gdb -tui
-target remote 192.168.122.35:5555
-continue
-```
-At this point you'll have three essential windows-
-* A VM running the wm
-* A terminal tailing the logs for the wm and its child processes
-* A terminal with gdb remotely attached to wm
-And that's all you need to debug. Be sure the host repo root has the same version of build output as on remote. That is needed for gdb.  
+#### App Selected
+![app](https://github.com/trent234/xwm/assets/22989914/24fb2318-3a57-4ae2-8b0c-d4f7dbfc6cb0)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,87 @@
+host_src = `pwd`.chomp
+
+Vagrant.configure("2") do |config|
+  config.vm.define "xwm-dev", primary: true do |xwm|
+    xwm.vm.box = "debian/bookworm64"
+    xwm.vm.hostname = "xwm-dev"
+    xwm.vm.network "private_network", ip: "192.168.122.35"
+    xwm.vm.synced_folder ".", "/home/vagrant/xwm", type: "rsync"
+    
+    xwm.vm.provision "shell", inline: <<-SHELL
+  set -e
+
+  echo "Installing dependencies..."
+  apt-get update
+  apt-get install -y \
+    git make gcc gdb gdbserver valgrind \
+    xorg libx11-dev libxft-dev dbus-x11 \
+    systemd
+
+  echo "Linking guest path to match host path for GDB..."
+  mkdir -p $(dirname #{host_src})
+  ln -sf /home/vagrant/xwm #{host_src}
+
+  echo "Setting X11 config for non-root user..."
+  echo "allowed_users=anybody" > /etc/X11/Xwrapper.config
+
+  echo "Building xwm..."
+  cd #{host_src}
+  make clean install
+
+  echo "Preparing log file..."
+  touch /var/log/wm
+  chmod 666 /var/log/wm
+
+  echo "Configuring autologin on tty1..."
+  mkdir -p /etc/systemd/system/getty@tty1.service.d
+  cat <<EOF >/etc/systemd/system/getty@tty1.service.d/autologin.conf
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty --autologin vagrant --noclear %I \$TERM
+EOF
+
+  echo "Enabling linger so X can run after boot..."
+  loginctl enable-linger vagrant
+
+  echo "Writing .xinitrc to start gdbserver..."
+  su - vagrant -c 'cat << "EOF" > ~/.xinitrc
+#!/bin/bash
+source "$HOME/.xwm_env"
+: "${HOST_IP:?Missing HOST_IP}" "${PORT:=5555}"
+
+export PATH="$HOME/.local/bin:$PATH"
+
+exec gdbserver $HOST_IP:$PORT wm > /var/log/wm 2>&1
+EOF
+chmod +x ~/.xinitrc'
+
+  echo "Starting X session automatically on login..."
+  su - vagrant -c 'echo "[ -z \\\"\\\$DISPLAY\\\" ] && [ \\\"\\\$(tty)\\\" = \\\"/dev/tty1\\\" ] && exec startx" > ~/.bash_profile'
+    SHELL
+
+    xwm.vm.provider :libvirt do |libvirt|
+      libvirt.memory = 2048
+      libvirt.cpus = 2
+
+      # Graphics configuration (stable and predictable)
+      libvirt.graphics_type = "vnc"
+      libvirt.graphics_port = 5901
+      libvirt.graphics_ip   = "127.0.0.1"
+      libvirt.video_type    = "qxl"
+      libvirt.keymap        = "en-us"
+    end
+  end
+
+  config.vm.post_up_message = <<-MESSAGE
+  Development environment ready for xwm.
+
+  To get started:
+    - SSH into the VM:        vagrant ssh
+    - Sync source manually:   vagrant rsync
+    - Start debugging:        make debug
+    - Tail runtime logs:      make tail-log
+
+  NOTE: Code is synced to /home/vagrant/xwm via rsync (not live).
+        Changes on host require 'vagrant rsync' to apply.
+  MESSAGE
+end

--- a/config.mk
+++ b/config.mk
@@ -2,6 +2,7 @@
 VERSION = 0.1
 
 # paths
+PREFIX = ${HOME}/.local
 COMMON = ../common
 WM = src/wm
 MENU = src/menu

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+HOST_IP=$(ip route | awk '/default/ {print $3}')
+echo "HOST_IP=$HOST_IP" > ~/.xwm_env
+
+cd /home/vagrant/xwm
+make clean install


### PR DESCRIPTION
# Add Remote Development Environment for `xwm` Debugging

## Summary

This PR introduces a fully automated remote development environment for `xwm` using **Vagrant**, **libvirt**, and **GDB**. It streamlines the build–test–debug cycle by replicating the host project structure inside a VM and enables seamless remote debugging and log inspection.

## Key Features

- **Vagrant-based provisioning**:
  - Installs development tools (`GDB`, `gdbserver`, `rsync`)
  - Enables GUI output via `remote-viewer` (SPICE/QEMU)
  - Sets up auto-login and `startx` on boot for graphical sessions

- **Makefile targets**:
  - `make rebuild` — Syncs source code and rebuilds `xwm` in the VM
  - `make tail-log` — Tails runtime logs from `/var/log/wm` inside the VM
  - `make view` — Opens the graphical environment using `remote-viewer`
  - `make debug` — Launches `gdb` in TUI mode and attaches to the remote `gdbserver`

- **Persistent path mapping**:
  - Ensures symbol resolution works correctly between host and VM

- **`.xinitrc` setup**:
  - Launches `gdbserver` and waits for GDB connection before executing `wm`

- **Documentation updates**:
  - New `development.md` with complete usage instructions
  - Expanded Makefile usage section in `README.md`

## Benefits

- Fast and reproducible development environment isolated from the host system
- Debug `wm` in a graphical VM with minimal manual setup
- Easily iterate by syncing code and restarting the debugger
- Matches target device characteristics more closely (e.g. PinePhone, reMarkable)

## Notes

- `.vagrant/` is now recommended to be ignored in `.gitignore`
- `gdbserver` remains running and can restart `wm` when GDB reconnects
- Tested with the `libvirt` provider — other providers may need adaptation